### PR TITLE
Transfusion Redux

### DIFF
--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -862,8 +862,8 @@ static const u8 sText_TargetPurged[] = _("{B_DEF_NAME_WITH_PREFIX} was purged of
 static const u8 sText_InvertedAreaCreated[] =_("An inverted area was created in which\ntype effectiveness is swapped!");
 static const u8 sText_InverseRoomEnds[] = _("Inverse Room wore off, and type\neffectiveness returned to normal!");
 static const u8 sText_TypesBecameInverted[] = _("Type effectiveness was\ninverted!");
-static const u8 sText_AttackerAcquiredType[] = _("{B_ATK_NAME_WITH_PREFIX} acquired\n{B_DEF_NAME_WITH_PREFIX}'s type!");
-static const u8 sText_TransfusionOver[] = _("All types were changed\nback to normal!");
+static const u8 sText_AttackerAcquiredType[] = _("{B_ATK_NAME_WITH_PREFIX} acquired\n{B_DEF_NAME_WITH_PREFIX}'s primary type!");
+static const u8 sText_TransfusionOver[] = _("All types were reverted\nback to normal!");
 
 
 const u8 *const gBattleStringsTable[BATTLESTRINGS_COUNT] =

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5575,18 +5575,18 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
             if (!(gMoveResultFlags & MOVE_RESULT_NO_EFFECT)
              && IsBattlerAlive(gBattlerAttacker)
              && TARGET_TURN_DAMAGED
-             && GetBattlerHoldEffect(gBattlerAttacker, TRUE) != HOLD_EFFECT_PROTECTIVE_PADS
-             && IsMoveMakingContact(move, gBattlerAttacker)
              && gBattleMons[gBattlerAttacker].ability != ABILITY_TRANSFUSION
-             && !gAbilitiesInfo[gBattleMons[gBattlerAttacker].ability].cantBeSuppressed)
-            {
-                gBattleMons[gBattlerAttacker].type1 = gSpeciesInfo[gBattleMons[gBattlerTarget].species].types[0];
-                gBattleMons[gBattlerAttacker].type2 = gSpeciesInfo[gBattleMons[gBattlerTarget].species].types[1];
-                BattleScriptPushCursor();
-                gBattlescriptCurrInstr = BattleScript_TransfusionActivates;
-                effect++;
-                break;
-            }
+             && !gAbilitiesInfo[gBattleMons[gBattlerAttacker].ability].cantBeSuppressed
+             && !(gBattleMons[gBattlerAttacker].type1 == gSpeciesInfo[gBattleMons[gBattlerTarget].species].types[0])
+             && !(gBattleMons[gBattlerAttacker].type2 == gSpeciesInfo[gBattleMons[gBattlerTarget].species].types[1]))
+                {
+                    gBattleMons[gBattlerAttacker].type1 = gSpeciesInfo[gBattleMons[gBattlerTarget].species].types[0];
+                    gBattleMons[gBattlerAttacker].type2 = gSpeciesInfo[gBattleMons[gBattlerTarget].species].types[0];
+                    BattleScriptPushCursor();
+                    gBattlescriptCurrInstr = BattleScript_TransfusionActivates;
+                    effect++;
+                    break;
+                }
             break;
         case ABILITY_WANDERING_SPIRIT:
             if (!(gMoveResultFlags & MOVE_RESULT_NO_EFFECT)


### PR DESCRIPTION
-Transfusion now works with any direct attack, and changes the attacker's type to the target's first type, monotype. -All type changes are reverted upon switch out
-Type changes are not reverted upon Transfusion mon fainting -Fixed message popup every time mon with Transfusion gets hit