### PR TITLE
Battle Intro Speedup Feature

### DIFF
--- a/include/battle_intro_speedup.h
+++ b/include/battle_intro_speedup.h
@@ -1,0 +1,16 @@
+#ifndef GUARD_BATTLE_INTRO_SPEEDUP_H
+#define GUARD_BATTLE_INTRO_SPEEDUP_H
+
+#include "main.h"
+
+// toggle on/off for battle intro speedup
+#define BATTLE_INTRO_SPEEDUP                    TRUE
+
+// speedup multiplier constants
+#define BATTLE_INTRO_SPEEDUP_MULTIPLIER        3
+
+#define ALPHA_BLEND_SPEEDUP_DIVISOR            1
+
+// RTODO: add logic for link and multi battles if desired.
+
+#endif // GUARD_BATTLE_INTRO_SPEEDUP_H

--- a/include/config/overworld.h
+++ b/include/config/overworld.h
@@ -70,9 +70,9 @@
 // To use the following features in scripting, replace the 0s with the flag ID you're assigning it to.
 // Eg: Replace with FLAG_UNUSED_0x264 so you can use that flag to toggle the feature.
 #define OW_FLAG_PAUSE_TIME          0  // If this flag is set and OW_USE_FAKE_RTC is enabled, seconds on the in-game clock will not advance.
-#define OW_FLAG_NO_ENCOUNTER        0  // If this flag is set, wild encounters will be disabled.
-#define OW_FLAG_NO_TRAINER_SEE      0  // If this flag is set, trainers will not battle the player unless they're talked to.
-#define OW_FLAG_NO_COLLISION        0  // If this flag is set, the player will be able to walk over tiles with collision. Mainly intended for debugging purposes.
+#define OW_FLAG_NO_ENCOUNTER        0x20  // If this flag is set, wild encounters will be disabled.
+#define OW_FLAG_NO_TRAINER_SEE      0x21  // If this flag is set, trainers will not battle the player unless they're talked to.
+#define OW_FLAG_NO_COLLISION        0x22  // If this flag is set, the player will be able to walk over tiles with collision. Mainly intended for debugging purposes.
 
 #define BATTLE_PYRAMID_RANDOM_ENCOUNTERS    FALSE    // If set to TRUE, battle pyramid Pokemon will be generated randomly based on the round's challenge instead of hardcoded in src/data/battle_frontier/battle_pyramid_level_50_wild_mons.h (or open_level_wild_mons.h)
 

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -42,9 +42,9 @@
 #define TEMP_FLAGS_END   FLAG_TEMP_1F
 #define NUM_TEMP_FLAGS   (TEMP_FLAGS_END - TEMP_FLAGS_START + 1)
 
-#define FLAG_UNUSED_0x020    0x20 // Unused Flag
-#define FLAG_UNUSED_0x021    0x21 // Unused Flag
-#define FLAG_UNUSED_0x022    0x22 // Unused Flag
+#define FLAG_UNUSED_0x020    0x20 // No Encounter Debug Flag
+#define FLAG_UNUSED_0x021    0x21 // No Trainer See Debug Flag
+#define FLAG_UNUSED_0x022    0x22 // No Collision Debug Flag
 #define FLAG_UNUSED_0x023    0x23 // Unused Flag
 #define FLAG_UNUSED_0x024    0x24 // Unused Flag
 #define FLAG_UNUSED_0x025    0x25 // Unused Flag

--- a/src/battle_controllers.c
+++ b/src/battle_controllers.c
@@ -7,6 +7,7 @@
 #include "battle_controllers.h"
 #include "battle_gfx_sfx_util.h"
 #include "battle_interface.h"
+#include "battle_intro_speedup.h"
 #include "battle_message.h"
 #include "battle_setup.h"
 #include "battle_tv.h"
@@ -2505,7 +2506,10 @@ void BtlController_HandleDrawTrainerPic(u32 battler, u32 trainerPicId, bool32 is
 
         gSprites[gBattlerSpriteIds[battler]].oam.paletteNum = IndexOfSpritePaletteTag(gTrainerSprites[trainerPicId].palette.tag);
         gSprites[gBattlerSpriteIds[battler]].x2 = -DISPLAY_WIDTH;
-        gSprites[gBattlerSpriteIds[battler]].sSpeedX = 2;
+        if (BATTLE_INTRO_SPEEDUP)
+            gSprites[gBattlerSpriteIds[battler]].sSpeedX = 2 * BATTLE_INTRO_SPEEDUP_MULTIPLIER; // Controls the speed at which trainer sprite enters the scene (original value of 2)
+        else
+            gSprites[gBattlerSpriteIds[battler]].sSpeedX = 2;
         gSprites[gBattlerSpriteIds[battler]].oam.affineParam = trainerPicId;
     }
     else // Player's side
@@ -2540,7 +2544,10 @@ void BtlController_HandleDrawTrainerPic(u32 battler, u32 trainerPicId, bool32 is
             gSprites[gBattlerSpriteIds[battler]].oam.paletteNum = battler;
         }
         gSprites[gBattlerSpriteIds[battler]].x2 = DISPLAY_WIDTH;
-        gSprites[gBattlerSpriteIds[battler]].sSpeedX = -2;
+        if (BATTLE_INTRO_SPEEDUP)
+            gSprites[gBattlerSpriteIds[battler]].sSpeedX = -2 * BATTLE_INTRO_SPEEDUP_MULTIPLIER; // Controls the speed at which player sprite enters the scene (original value of 2)
+        else
+            gSprites[gBattlerSpriteIds[battler]].sSpeedX = -2;
     }
     gSprites[gBattlerSpriteIds[battler]].callback = SpriteCB_TrainerSlideIn;
 
@@ -2559,7 +2566,10 @@ void BtlController_HandleTrainerSlide(u32 battler, u32 trainerPicId)
                                                          30);
         gSprites[gBattlerSpriteIds[battler]].oam.paletteNum = battler;
         gSprites[gBattlerSpriteIds[battler]].x2 = -96;
-        gSprites[gBattlerSpriteIds[battler]].sSpeedX = 2;
+        if (BATTLE_INTRO_SPEEDUP)
+            gSprites[gBattlerSpriteIds[battler]].sSpeedX = 2 * BATTLE_INTRO_SPEEDUP_MULTIPLIER; // Controls the speed at which trainer sprite slides into the scene (original value of 2)
+        else
+            gSprites[gBattlerSpriteIds[battler]].sSpeedX = 2;
     }
     else
     {
@@ -2570,8 +2580,11 @@ void BtlController_HandleTrainerSlide(u32 battler, u32 trainerPicId)
         gSprites[gBattlerSpriteIds[battler]].oam.paletteNum = IndexOfSpritePaletteTag(gTrainerSprites[trainerPicId].palette.tag);
         gSprites[gBattlerSpriteIds[battler]].x2 = 96;
         gSprites[gBattlerSpriteIds[battler]].x += 32;
-        gSprites[gBattlerSpriteIds[battler]].sSpeedX = -2;
-    }
+        if (BATTLE_INTRO_SPEEDUP)
+            gSprites[gBattlerSpriteIds[battler]].sSpeedX = -2 * BATTLE_INTRO_SPEEDUP_MULTIPLIER; // Controls the speed at which players sprite slides into the scene (original value of 2)
+        else
+            gSprites[gBattlerSpriteIds[battler]].sSpeedX = -2;
+        }
     gSprites[gBattlerSpriteIds[battler]].callback = SpriteCB_TrainerSlideIn;
 
     gBattlerControllerFuncs[battler] = Controller_WaitForTrainerPic;

--- a/src/battle_intro.c
+++ b/src/battle_intro.c
@@ -1,6 +1,7 @@
 #include "global.h"
 #include "battle.h"
 #include "battle_anim.h"
+#include "battle_intro_speedup.h"
 #include "battle_main.h"
 #include "battle_setup.h"
 #include "bg.h"
@@ -152,8 +153,10 @@ static void BattleIntroSlideEnd(u8 taskId)
 static void BattleIntroSlide1(u8 taskId)
 {
     int i;
-
-    gBattle_BG1_X += 6;
+    if (BATTLE_INTRO_SPEEDUP)
+        gBattle_BG1_X += 6 * BATTLE_INTRO_SPEEDUP_MULTIPLIER; // Controls the speed at which battle intro foreground graphics (ex. grass for overworld encounters) slide across the screen during battle intro (original value of 6)
+    else
+        gBattle_BG1_X += 6;
     switch (gTasks[taskId].tState)
     {
     case 0:
@@ -177,7 +180,7 @@ static void BattleIntroSlide1(u8 taskId)
         break;
     case 2:
         gBattle_WIN0V -= 0xFF;
-        if ((gBattle_WIN0V & 0xFF00) == 0x3000)
+        if ((gBattle_WIN0V & 0xFF00) == 0x3000) // when gBattle_WIN0V reaches 0x3000, do something to the black bars on into
         {
             gTasks[taskId].tState++;
             gTasks[taskId].data[2] = DISPLAY_WIDTH;
@@ -195,12 +198,22 @@ static void BattleIntroSlide1(u8 taskId)
             if (gTasks[taskId].tTerrain == BATTLE_TERRAIN_LONG_GRASS)
             {
                 if (gBattle_BG1_Y != (u16)(-80))
-                    gBattle_BG1_Y -= 2;
+                {
+                    if (BATTLE_INTRO_SPEEDUP)
+                        gBattle_BG1_Y -= 2 * BATTLE_INTRO_SPEEDUP_MULTIPLIER; // Controls the speed at which battle intro foreground graphics (ex. grass for overworld encounters) exit the screen vertically during battle intro (original value of 2)
+                    else
+                        gBattle_BG1_Y -= 2;
+                }
             }
             else
             {
                 if (gBattle_BG1_Y != (u16)(-56))
-                    gBattle_BG1_Y -= 1;
+                {
+                    if (BATTLE_INTRO_SPEEDUP)
+                        gBattle_BG1_Y -= 1 * BATTLE_INTRO_SPEEDUP_MULTIPLIER; // Controls the speed at which battle intro foreground graphics (ex. grass for overworld encounters) exit the screen vertically during battle intro (original value of 1)
+                    else
+                        gBattle_BG1_Y -= 1;
+                }
             }
         }
 
@@ -208,7 +221,12 @@ static void BattleIntroSlide1(u8 taskId)
             gBattle_WIN0V -= 0x3FC;
 
         if (gTasks[taskId].data[2])
-            gTasks[taskId].data[2] -= 2;
+        {
+            if (BATTLE_INTRO_SPEEDUP)
+                gTasks[taskId].data[2] -= 2 * BATTLE_INTRO_SPEEDUP_MULTIPLIER; // Controls the speed at which battle intro background graphics on BG3 (player and enemy positions) slide onto the screen horizontally (original value of 2)
+            else
+                gTasks[taskId].data[2] -= 2;
+        }
 
         // Scanline settings have already been set in CB2_InitBattleInternal()
         for (i = 0; i < DISPLAY_HEIGHT / 2; i++)
@@ -242,10 +260,16 @@ static void BattleIntroSlide2(u8 taskId)
     {
     case BATTLE_TERRAIN_SAND:
     case BATTLE_TERRAIN_WATER:
-        gBattle_BG1_X += 8;
+        if (BATTLE_INTRO_SPEEDUP)
+            gBattle_BG1_X += 8 * BATTLE_INTRO_SPEEDUP_MULTIPLIER;
+        else
+            gBattle_BG1_X += 8;
         break;
     case BATTLE_TERRAIN_UNDERWATER:
-        gBattle_BG1_X += 6;
+        if (BATTLE_INTRO_SPEEDUP)
+            gBattle_BG1_X += 6 * BATTLE_INTRO_SPEEDUP_MULTIPLIER;
+        else
+            gBattle_BG1_X += 6;
         break;
     }
 
@@ -253,9 +277,19 @@ static void BattleIntroSlide2(u8 taskId)
     {
         gBattle_BG1_Y = Cos2(gTasks[taskId].data[6]) / 512 - 8;
         if (gTasks[taskId].data[6] < 180)
-            gTasks[taskId].data[6] += 4;
+        {
+            if (BATTLE_INTRO_SPEEDUP)
+                gTasks[taskId].data[6] += 4 * BATTLE_INTRO_SPEEDUP_MULTIPLIER;
+            else
+                gTasks[taskId].data[6] += 4;
+        }
         else
-            gTasks[taskId].data[6] += 6;
+        {
+            if (BATTLE_INTRO_SPEEDUP)
+                gTasks[taskId].data[6] += 6 * BATTLE_INTRO_SPEEDUP_MULTIPLIER;
+            else
+                gTasks[taskId].data[6] += 6;
+        }
 
         if (gTasks[taskId].data[6] == 360)
             gTasks[taskId].data[6] = 0;
@@ -289,7 +323,10 @@ static void BattleIntroSlide2(u8 taskId)
         {
             gTasks[taskId].tState++;
             gTasks[taskId].data[2] = DISPLAY_WIDTH;
-            gTasks[taskId].data[3] = 32;
+            if (BATTLE_INTRO_SPEEDUP)
+                gTasks[taskId].data[3] = ALPHA_BLEND_SPEEDUP_DIVISOR % 32; // Value that once reaches zero, sets GPU regs on BG3 to alpha blend fade the foreground graphics.
+            else
+                gTasks[taskId].data[3] = 32;
             gTasks[taskId].data[5] = 1;
             gIntroSlideFlags &= ~1;
         }
@@ -317,8 +354,12 @@ static void BattleIntroSlide2(u8 taskId)
             gBattle_WIN0V -= 0x3FC;
 
         if (gTasks[taskId].data[2])
-            gTasks[taskId].data[2] -= 2;
-
+        {
+            if (BATTLE_INTRO_SPEEDUP)
+                gTasks[taskId].data[2] -= 2 * BATTLE_INTRO_SPEEDUP_MULTIPLIER;
+            else
+                gTasks[taskId].data[2] -= 2;
+        }
         // Scanline settings have already been set in CB2_InitBattleInternal()
         for (i = 0; i < DISPLAY_HEIGHT / 2; i++)
             gScanlineEffectRegBuffers[gScanlineEffect.srcBuffer][i] = gTasks[taskId].data[2];
@@ -349,8 +390,10 @@ static void BattleIntroSlide2(u8 taskId)
 static void BattleIntroSlide3(u8 taskId)
 {
     int i;
-
-    gBattle_BG1_X += 8;
+    if (BATTLE_INTRO_SPEEDUP)
+        gBattle_BG1_X += 8 * BATTLE_INTRO_SPEEDUP_MULTIPLIER;
+    else
+        gBattle_BG1_X += 8;
     switch (gTasks[taskId].tState)
     {
     case 0:
@@ -382,7 +425,10 @@ static void BattleIntroSlide3(u8 taskId)
         {
             gTasks[taskId].tState++;
             gTasks[taskId].data[2] = DISPLAY_WIDTH;
-            gTasks[taskId].data[3] = 32;
+            if (BATTLE_INTRO_SPEEDUP)
+                gTasks[taskId].data[3] = ALPHA_BLEND_SPEEDUP_DIVISOR % 32;
+            else
+                gTasks[taskId].data[3] = 32;
             gTasks[taskId].data[5] = 1;
             gIntroSlideFlags &= ~1;
         }
@@ -405,7 +451,12 @@ static void BattleIntroSlide3(u8 taskId)
             gBattle_WIN0V -= 0x3FC;
 
         if (gTasks[taskId].data[2])
-            gTasks[taskId].data[2] -= 2;
+        {
+            if (BATTLE_INTRO_SPEEDUP)
+                gTasks[taskId].data[2] -= 2 * BATTLE_INTRO_SPEEDUP_MULTIPLIER;
+            else
+                gTasks[taskId].data[2] -= 2;
+        }
 
         // Scanline settings have already been set in CB2_InitBattleInternal()
         for (i = 0; i < DISPLAY_HEIGHT / 2; i++)

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -6,6 +6,7 @@
 #include "battle_arena.h"
 #include "battle_controllers.h"
 #include "battle_interface.h"
+#include "battle_intro_speedup.h"
 #include "battle_main.h"
 #include "battle_message.h"
 #include "battle_pyramid.h"
@@ -2658,7 +2659,10 @@ static void SpriteCB_MoveWildMonToRight(struct Sprite *sprite)
 {
     if ((gIntroSlideFlags & 1) == 0)
     {
-        sprite->x2 += 2;
+        if (BATTLE_INTRO_SPEEDUP)
+            sprite->x2 += 2 * BATTLE_INTRO_SPEEDUP_MULTIPLIER; // Controls the speed at which wild Pokemon sprite enters the battle scene horizontally (original value of 2)
+        else
+            sprite->x2 += 2;
         if (sprite->x2 == 0)
         {
             sprite->callback = SpriteCB_WildMonShowHealthbox;

--- a/src/data/pokemon/level_up_learnsets/gen_9.h
+++ b/src/data/pokemon/level_up_learnsets/gen_9.h
@@ -23995,7 +23995,7 @@ static const struct LevelUpMove sDraklownLevelUpLearnset[] = {
    LEVEL_UP_END
    };
 static const struct LevelUpMove sDrattelLevelUpLearnset[] = {
-   LEVEL_UP_MOVE( 1, MOVE_STEEL_BEAM),,
+   LEVEL_UP_MOVE( 1, MOVE_STEEL_BEAM),
    LEVEL_UP_END
    };
 static const struct LevelUpMove sZillichinaLevelUpLearnset[] = {


### PR DESCRIPTION
-Adds option to speed up battle intros with wild encounters and trainers.
-Toggle on or off by going to include/battle_intro_speedup.h and setting BATTLE_INTRO_SPEEDUP to true or false.
-Can adjust speed up multipliers as needed.
